### PR TITLE
解像度の違う端末でインクを落とす位置がずれる問題の修正

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,6 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedGame"
+  ]
+}

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7c5284aa582532049ab3bf55c41f9603
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/InGame.unity
+++ b/Assets/Scenes/InGame.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -42,8 +42,8 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -66,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -341,7 +338,7 @@ Transform:
   m_GameObject: {fileID: 208809778}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0, y: 1, z: 10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -688,15 +685,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1213,15 +1212,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1488,7 +1489,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -60}
+  m_AnchoredPosition: {x: 0, y: -59.999756}
   m_SizeDelta: {x: 164, y: -120}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!114 &947713021
@@ -1910,15 +1911,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0

--- a/Assets/Scripts/InGame/GameManager.cs
+++ b/Assets/Scripts/InGame/GameManager.cs
@@ -164,9 +164,30 @@ public class GameManager : MonoBehaviour
         if (currentPalatteInk == null) return;
         if (currentPalatteInk.IsUsed) return;
 
+        var screenSize = new Vector2(Screen.width, Screen.height);
+        Debug.Log($"Current screen size: {screenSize.x}x{screenSize.y}");
+        var aspectRatio = screenSize.x / screenSize.y;
+        Debug.Log($"Current aspect ratio: {aspectRatio}");
+        var adjustRatio = 1f;
+        if (aspectRatio < 1612 / 720)
+        {
+            Debug.LogWarning("y length large");
+            adjustRatio = 1612 / screenSize.x;
+        }
+        else if (aspectRatio > 1612 / 720)
+        {
+            Debug.LogWarning("x length large");
+            adjustRatio = 720 / screenSize.y;
+        }
+        else
+        {
+            Debug.LogWarning("Aspect ratio is 16:9.");
+            adjustRatio = 1612 / screenSize.x;
+        }
+
         // 生成
         var ink = Instantiate(inkPrefab, inks);
-        ink.transform.position = calcCamera.ScreenToWorldPoint(new Vector3(position.x, position.y, 10f));
+        ink.transform.position = calcCamera.ScreenToWorldPoint(new Vector3(position.x * adjustRatio, position.y * adjustRatio, 10f));
 
         // 色設定
         var image = ink.GetComponent<Image>();

--- a/Assets/Scripts/InGame/GameManager.cs
+++ b/Assets/Scripts/InGame/GameManager.cs
@@ -168,22 +168,7 @@ public class GameManager : MonoBehaviour
         Debug.Log($"Current screen size: {screenSize.x}x{screenSize.y}");
         var aspectRatio = screenSize.x / screenSize.y;
         Debug.Log($"Current aspect ratio: {aspectRatio}");
-        var adjustRatio = 1f;
-        if (aspectRatio < 1612 / 720)
-        {
-            Debug.LogWarning("y length large");
-            adjustRatio = 1612 / screenSize.x;
-        }
-        else if (aspectRatio > 1612 / 720)
-        {
-            Debug.LogWarning("x length large");
-            adjustRatio = 720 / screenSize.y;
-        }
-        else
-        {
-            Debug.LogWarning("Aspect ratio is 16:9.");
-            adjustRatio = 1612 / screenSize.x;
-        }
+        var adjustRatio = 1612 / screenSize.x; // 1612は想定している画面幅;
 
         // 生成
         var ink = Instantiate(inkPrefab, inks);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.collab-proxy": "2.9.3",
+    "com.unity.device-simulator.devices": "1.0.0",
     "com.unity.feature.development": "1.0.2",
     "com.unity.inputsystem": "1.14.2",
     "com.unity.multiplayer.center": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -69,6 +69,13 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.device-simulator.devices": {
+      "version": "1.0.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.editorcoroutines": {
       "version": "1.0.0",
       "depth": 1,
@@ -193,9 +200,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -63,6 +63,11 @@
         },
         {
             "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
             "type": "UnityEngine.PhysicsMaterial2D",
             "defaultInstantiationMode": 0
         },


### PR DESCRIPTION
https://github.com/Bamiry/Spreadink/issues/2

原因はスクリーンサイズの変動を考慮していない変換だったこと
想定サイズ（1612×720）からの倍率をかけてScreenToWorldPointに入れてやることで解決
ただこれだとアスペクト比の違う端末の場合、縦に長いと縦に、横に長いと横にずれる問題があったため、常に横幅は完全に描画されるため横の倍率をかけてあげることで解決

これによって縦に長い場合も横に長い場合にも対応
次はそもそも余白が生まれる仕様になってるのを修正する