### PR TITLE
縦に長い端末で余白ができてしまう問題の修正

### DIFF
--- a/Assets/Scenes/InGame.unity
+++ b/Assets/Scenes/InGame.unity
@@ -1637,9 +1637,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 779711795}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -360}
   m_SizeDelta: {x: 1448, y: 600}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1045487855
@@ -2500,7 +2500,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.8980393, g: 0.8980393, b: 0.8980393, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scenes/InGame.unity
+++ b/Assets/Scenes/InGame.unity
@@ -2604,9 +2604,9 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 779711795}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -360}
   m_SizeDelta: {x: 1448, y: 600}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &2037466660

--- a/Assets/Scripts/InGame/GameManager.cs
+++ b/Assets/Scripts/InGame/GameManager.cs
@@ -168,11 +168,14 @@ public class GameManager : MonoBehaviour
         Debug.Log($"Current screen size: {screenSize.x}x{screenSize.y}");
         var aspectRatio = screenSize.x / screenSize.y;
         Debug.Log($"Current aspect ratio: {aspectRatio}");
-        var adjustRatio = 1612 / screenSize.x; // 1612は想定している画面幅;
+        var adjustRatio = screenSize.x / 1612f; // 1612は想定している画面幅;
+        var margin = (screenSize.y - (720 * adjustRatio)) / 2; // 720はヘッダー＋Stage高さ
+        Debug.Log($"adjustRatio:{adjustRatio} ,Header size:{120 * adjustRatio}, stage size:{600 * adjustRatio},Margin size:{margin}");
 
         // 生成
         var ink = Instantiate(inkPrefab, inks);
-        ink.transform.position = calcCamera.ScreenToWorldPoint(new Vector3(position.x * adjustRatio, position.y * adjustRatio, 10f));
+        // 横幅はRatioで倍率調整、縦幅はヘッダー分引いて倍率調整
+        ink.transform.position = calcCamera.ScreenToWorldPoint(new Vector3(position.x / adjustRatio, (position.y - margin) / adjustRatio, 10f));
 
         // 色設定
         var image = ink.GetComponent<Image>();


### PR DESCRIPTION
https://github.com/Bamiry/Spreadink/issues/18

1612×720の際の位置を基準に、アンカーを左中央にすることでStageをヘッダーを除いた高さの中央にそろうようにした
加えてインクドロップ位置の補正をした