### PR TITLE
ハンバーガーの音量バーが一気に移動する違和感の修正

### DIFF
--- a/Assets/Prefabs/HamburgerMenu/Volume.prefab
+++ b/Assets/Prefabs/HamburgerMenu/Volume.prefab
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6ee3329b89e384e80a77636fbd22c365, type: 3}
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -176,7 +176,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -458,7 +458,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.79607844, g: 0.9490196, b: 0.81960785, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scripts/Audio/VolumeChange.cs
+++ b/Assets/Scripts/Audio/VolumeChange.cs
@@ -18,7 +18,7 @@ public class VolumeChange : MonoBehaviour
             // SoundManagerの現在の音量で初期値を設定
             if (SoundManager.Instance != null)
             {
-                slider.value = SoundManager.Instance.MasterVolumeScaler;
+                slider.SetValueWithoutNotify(SoundManager.Instance.MasterVolumeScaler);
             }
         }
     }


### PR DESCRIPTION
初期化をslider.SetValueWithoutNotifyでやると一気に移動しなくなる
```
async void Awake()
    {
        await UniTask.WaitUntil(() => ManagerSceneAutoLoader.IsManagerSceneLoaded);
        slider = GetComponent<Slider>();
        if (slider != null)
        {
            slider.onValueChanged.AddListener(OnSliderValueChanged);
            // SoundManagerの現在の音量で初期値を設定
            if (SoundManager.Instance != null)
            {
                slider.SetValueWithoutNotify(SoundManager.Instance.MasterVolumeScaler);
            }
        }
    }
```